### PR TITLE
fix goreleaser yml

### DIFF
--- a/.goreleaser-internal.yml
+++ b/.goreleaser-internal.yml
@@ -1,3 +1,5 @@
+version: 2
+
 before:
   hooks:
     - go mod download
@@ -27,6 +29,9 @@ dockers:
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
       - "--label=org.opencontainers.image.version={{.Env.INTERNAL_VERSION}}"
       - "--label=org.opencontainers.image.source=https://github.com/confluentinc/boring-registry"
+
+release:
+  disable: true
 
 checksum:
   name_template: "checksums.txt"

--- a/.goreleaser-internal.yml
+++ b/.goreleaser-internal.yml
@@ -34,7 +34,8 @@ release:
   disable: true
 
 checksum:
-  name_template: "checksums.txt"
+  disable: true
+
 changelog:
   sort: asc
   filters:


### PR DESCRIPTION
- use `version 2` of goreleaser 
- disable publishing to github
- disable signing since we didn't configure gpg key etc.