### PR TITLE
push directly instead of using buildx

### DIFF
--- a/.goreleaser-internal.yml
+++ b/.goreleaser-internal.yml
@@ -22,6 +22,7 @@ dockers:
       - "{{ .Env.ECR_REGISTRY }}/docker/prod/{{ .Env.IMAGE_REPOSITORY }}:{{ .Env.INTERNAL_VERSION }}"
     dockerfile: Dockerfile
     use: buildx
+    push: true
     build_flag_templates:
       - "--platform=linux/amd64,linux/arm64"
       - "--label=org.opencontainers.image.created={{.Date}}"


### PR DESCRIPTION
This is to fix this error: https://semaphore.ci.confluent.io/jobs/c267af38-436b-43f4-af53-0d7931a64d7b

buildx doesn't support multi-arch images