### PR TITLE
whitespace change

### DIFF
--- a/helm-release.sh
+++ b/helm-release.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-
 set -exuo pipefail
 
 ENV=${ENV:-prod}


### PR DESCRIPTION
This is a simple whitespace change to force an image rebuild. The helm publish was broken because the ECR repo didn't exist. Now that it it exists. The pipeline should work