### PR TITLE
fix: bump Go to 1.26.3 to remediate stdlib CVEs (VM-7372)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # ARG before first stage to share the value across multiple stages
 ARG BASEDIR=/go/src/github.com/boring-registry/boring-registry
 
-FROM golang:1.26.2 AS build
+FROM golang:1.26.3 AS build
 
 ARG VERSION
 ARG GIT_COMMIT

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/boring-registry/boring-registry
 
-go 1.26.2
+go 1.26.3
 
 require (
 	cloud.google.com/go/iam v1.5.2


### PR DESCRIPTION
## Summary

Upgrades the Go toolchain from **1.26.2 → 1.26.3** in both the `go.mod` directive and the `Dockerfile` build stage to remediate the HIGH-severity Go stdlib CVEs reported in [VM-7372](https://confluentinc.atlassian.net/browse/VM-7372) / DP-19049 against the deployed `boring-registry:0.1.1` image.

The shipped binary is compiled by the `golang` build stage in the `Dockerfile`, so bumping that base image is what actually remediates the deployed image; `go.mod` is kept in sync.

## CVEs remediated (all patched in Go 1.26.3)

| CVE | Component |
| --- | --- |
| CVE-2026-33811 | `net` — `LookupCNAME` with cgo DNS resolver |
| CVE-2026-33814 | `net/http2` — infinite loop on SETTINGS frames |
| CVE-2026-39820 | `net/mail` — `ParseAddress`/`ParseAddressList` |
| CVE-2026-39836 | `net` — NUL byte in `Dial`/`LookupPort` on Windows |
| CVE-2026-42499 | `net/mail` — DoS via `consumePhrase` |

## Validation

- `go build ./...` — success
- `go vet ./...` — no issues
- `go test ./...` — 377 passed across 13 packages

No dependency changes, so `vendor/` is untouched. InfoSec's Trivy PR scan will confirm the stdlib CVEs are cleared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[VM-7372]: https://confluentinc.atlassian.net/browse/VM-7372?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ