### PR TITLE
ci: make Renovate track Go version promptly and across both managers

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -39,12 +39,14 @@
       ]
     },
     {
-      "matchPackageNames": [
-        "go",
-        "golang"
+      "matchManagers": [
+        "gomod",
+        "dockerfile"
       ],
-      "schedule": [
-        "* 2 * * 0"
+      "matchDepNames": [
+        "go",
+        "golang",
+        "toolchain"
       ],
       "groupName": "go version",
       "groupSlug": "go-version"


### PR DESCRIPTION
## Summary

Fixes two gaps in the `go version` Renovate rule that surfaced while remediating [VM-7372](https://confluentinc.atlassian.net/browse/VM-7372) (Go stdlib CVEs). Today Renovate produces **no** Go-bump PR for that CVE, for two reasons this PR addresses:

### 1. Remove the Sunday-only schedule
The rule was gated to `"* 2 * * 0"` — only Sundays 02:00–02:59 UTC. A Go patch released any other day waits up to a week before Renovate even attempts a PR, which doesn't fit VM CVE SLAs (VM-7372 is HIGH / 30-day SLA). Dropping the schedule lets the group run on the default cadence.

### 2. Track both managers, not just the Dockerfile
Scoped the rule by `matchManagers: [gomod, dockerfile]` + `matchDepNames: [go, golang, toolchain]` so it covers **both**:
- the `golang:1.x` build image in the `Dockerfile` (dockerfile manager), and
- the `go` / `toolchain` directive in `go.mod` (gomod manager).

The previous merged Go bump (#16) only touched the Dockerfile, leaving `go.mod` stale.

## Context / why now
The deployed image CVEs in VM-7372 are in the **Go stdlib** (1.26.2 → 1.26.3). The toolchain bump is being handled directly in #31; this PR ensures future Go CVEs are picked up automatically by Renovate without manual intervention.

## Validation
- `jq empty renovate.json` — valid JSON.
- Uses standard documented Renovate fields (`matchManagers`, `matchDepNames`, `groupName`, `groupSlug`). (Could not run `renovate-config-validator` locally — no Node in this env; reviewer CI / Mend will validate.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[VM-7372]: https://confluentinc.atlassian.net/browse/VM-7372?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ